### PR TITLE
Operator split fix

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5,6 +5,3 @@
 [submodule "builtins"]
 	path = src/builtins
 	url = git@github.com:lithiumox-codam/built-ins.git
-[submodule "readline"]
-	path = readline
-	url = git://git.savannah.gnu.org/readline.git

--- a/Makefile
+++ b/Makefile
@@ -29,15 +29,12 @@ SRC = main \
 SRCS = $(addsuffix .c, $(addprefix src/, $(SRC)))
 OBJS = $(patsubst src/%.c, build/%.o, $(SRCS))
 LIBFT = libft/libft.a
-READLINE = readline/libreadline.a
 
 DEBUG ?= 0
 DEBUG_FLAGS = -g
-G_FLAGS = -DREADLINE_LIBRARY
 CODAM_FLAGS = -Wall -Wextra -Werror
-LIBS = libft/libft.a readline/libreadline.a readline/libhistory.a
-LINKER = -lncurses
-INCLUDES = -I $(CURDIR)/includes -I $(CURDIR)/libft/includes -I $(CURDIR)/readline
+LINKER = -lreadline
+INCLUDES = -I $(CURDIR)/includes -I $(CURDIR)/libft/includes
 
 COLOR_INFO = \033[1;36m
 COLOR_SUCCESS = \033[1;32m
@@ -52,7 +49,7 @@ all: $(NAME)
 
 $(NAME): $(LIBFT) $(OBJS)
 	@printf "$(COLOR_INFO)$(EMOJI_INFO)  Compiling $(NAME)...$(COLOR_RESET)\t"
-	@cc $(OBJS) $(CODAM_FLAGS) $(if DEBUG, $(DEBUG_FLAGS)) -DDEBUG=$(DEBUG) $(LINKER) $(INCLUDES) $(LIBS) -o $@
+	@cc $(OBJS) $(CODAM_FLAGS) $(if DEBUG, $(DEBUG_FLAGS)) -DDEBUG=$(DEBUG) $(LINKER) $(INCLUDES) $(LIBFT) -o $@
 	@sleep 0.25
 	@printf "✅\n"
 
@@ -66,14 +63,6 @@ $(LIBFT):
 	@printf "✅\n"
 	@printf "$(COLOR_INFO)$(EMOJI_INFO)  Building Libft...$(COLOR_RESET)\t\t"
 	@$(MAKE) -C libft DEBUG=$(DEBUG) > /dev/null
-	@sleep 0.25
-	@printf "✅\n"
-
-$(READLINE):
-	@printf "$(COLOR_INFO)$(EMOJI_INFO)  Building Readline...$(COLOR_RESET)\t"
-	@cd readline && ./configure > /dev/null
-	@$(MAKE) static -C readline > /dev/null
-	@rm -rf doc && rm -rf examples
 	@sleep 0.25
 	@printf "✅\n"
 
@@ -105,8 +94,6 @@ re:
 
 bonus: all
 
-readline: $(READLINE)
-
 module-update:
 	@printf "$(COLOR_INFO)$(EMOJI_INFO)  Updating submodules...$(COLOR_RESET)\t"
 	@git submodule update --remote --merge
@@ -114,4 +101,3 @@ module-update:
 	@printf "✅\n"
 
 .PHONY: all clean fclean run re module-update
-

--- a/includes/enum.h
+++ b/includes/enum.h
@@ -6,7 +6,7 @@
 /*   By: mdekker/jde-baai <team@codam.nl>             +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2023/07/13 17:41:00 by mdekker/jde   #+#    #+#                 */
-/*   Updated: 2023/09/11 20:12:01 by mdekker/jde   ########   odam.nl         */
+/*   Updated: 2023/09/21 02:48:06 by mdekker/jde   ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -72,7 +72,8 @@ typedef enum e_exit
 	NO_SUCH,
 	SYNTAX,
 	SYNTAX_MINI,
-	SIGNAL_C
+	SIGNAL_C,
+	OUT_OF_SCOPE
 }	t_exit;
 
 /**

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -6,7 +6,7 @@
 /*   By: mdekker/jde-baai <team@codam.nl>             +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2023/07/09 21:25:59 by mdekker       #+#    #+#                 */
-/*   Updated: 2023/09/15 17:02:28 by mdekker/jde   ########   odam.nl         */
+/*   Updated: 2023/09/20 22:59:59 by mdekker/jde   ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -94,7 +94,7 @@ void	clear_exec(t_exec *exec);
 /* general utils */
 void	exit_mini(char *str, int exit_code);
 bool	set_err(t_exit type, char *msg, t_shell *data);
-void	exec_err(t_group *group, t_exit type);
+void	exec_err(char *str, t_exit type);
 void	write_err(t_shell *data);
 t_token	*rm_quotes(t_token *token, bool set_string);
 bool	type_compare(size_t num_args, t_types type, ...);

--- a/includes/structs.h
+++ b/includes/structs.h
@@ -6,7 +6,7 @@
 /*   By: mdekker/jde-baai <team@codam.nl>             +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2023/07/10 11:15:16 by mdekker       #+#    #+#                 */
-/*   Updated: 2023/09/11 12:29:29 by mdekker/jde   ########   odam.nl         */
+/*   Updated: 2023/09/20 22:34:57 by mdekker/jde   ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -68,6 +68,26 @@ typedef struct s_exec
 }				t_exec;
 
 /**
+ * @brief The global struct
+ *
+ * @param token_vec The token_vec vector from the lexer and parser;
+ * @param env The environment variables;
+ * @param data to be passed to the executor;
+ * @param exit_type The type of exit;
+ * @param exit_msg The message to be printed as part of err()
+ * @warning exit_msg will not be freed by err()
+ */
+typedef struct s_shell
+{
+	t_vector	token_vec;
+	t_vector	env;
+	t_exec		*exec;
+	t_exit		exit_type;
+	char		*exit_msg;
+	bool		exit_shell;
+}				t_shell;
+
+/**
  * @brief a group to be individually executed.
  * @param cmd The command to be executed
  * @param args The arguments to be passed to the execve
@@ -88,26 +108,6 @@ typedef struct s_group
 	int			right_pipe[2];
 	t_shell		*data;
 }				t_group;
-
-/**
- * @brief The global struct
- *
- * @param token_vec The token_vec vector from the lexer and parser;
- * @param env The environment variables;
- * @param data to be passed to the executor;
- * @param exit_type The type of exit;
- * @param exit_msg The message to be printed as part of err()
- * @warning exit_msg will not be freed by err()
- */
-typedef struct s_shell
-{
-	t_vector	token_vec;
-	t_vector	env;
-	t_exec		*exec;
-	t_exit		exit_type;
-	char		*exit_msg;
-	bool		exit_shell;
-}				t_shell;
 
 /**
  * @brief The struct for the parser functions.

--- a/src/checker/index.c
+++ b/src/checker/index.c
@@ -6,7 +6,7 @@
 /*   By: mdekker/jde-baai <team@codam.nl>             +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2023/08/02 16:57:32 by mdekker/jde   #+#    #+#                 */
-/*   Updated: 2023/09/15 16:50:23 by mdekker/jde   ########   odam.nl         */
+/*   Updated: 2023/09/21 02:38:59 by mdekker/jde   ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -39,7 +39,7 @@ static bool	check_double_ops(t_vector *found, t_shell *data)
 		if (next_found->index - current_found->index == 1)
 			if (current_token->type == next_token->type)
 				return (set_err(SYNTAX, type_symbol(current_token->type), data),
-						false);
+					false);
 		i++;
 	}
 	return (true);
@@ -78,9 +78,7 @@ bool	check_tokens(t_shell *data)
 	token = (t_token *)found_item->item;
 	if (found_item->index == 0 && type_compare(1, token->type, PIPE))
 		return (set_err(SYNTAX, type_symbol(token->type), data),
-				vec_free(found),
-				free(found),
-				false);
+			vec_free(found), free(found), false);
 	else if (found && !check_double_ops(found, data))
 	{
 		vec_free(found);

--- a/src/debug/print_vector.c
+++ b/src/debug/print_vector.c
@@ -6,7 +6,7 @@
 /*   By: mdekker/jde-baai <team@codam.nl>             +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2023/07/20 13:51:45 by mdekker/jde   #+#    #+#                 */
-/*   Updated: 2023/09/13 22:09:41 by mdekker/jde   ########   odam.nl         */
+/*   Updated: 2023/09/21 02:31:49 by mdekker/jde   ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 

--- a/src/debug/print_vector.c
+++ b/src/debug/print_vector.c
@@ -6,11 +6,27 @@
 /*   By: mdekker/jde-baai <team@codam.nl>             +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2023/07/20 13:51:45 by mdekker/jde   #+#    #+#                 */
-/*   Updated: 2023/09/21 02:31:49 by mdekker/jde   ########   odam.nl         */
+/*   Updated: 2023/09/21 03:06:08 by mdekker/jde   ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
+#include <execinfo.h>
 #include <minishell.h>
+
+void	print_stack_trace(void)
+{
+	void	*array[10];
+	size_t	size;
+	char	**strings;
+	size_t	i;
+
+	size = backtrace(array, 10);
+	strings = backtrace_symbols(array, size);
+	printf("Obtained %zd stack frames.\n", size);
+	for (i = 0; i < size; i++)
+		printf("%s\n", strings[i]);
+	free(strings);
+}
 
 /**
  * @brief Prints data in a vector in a pretty way
@@ -22,6 +38,7 @@ void	print_vector(t_vector *vec, void (*printer)(void *, size_t))
 {
 	size_t	i;
 
+	// print_stack_trace();
 	i = 0;
 	if (!DEBUG)
 		return ;

--- a/src/exec/redirect.c
+++ b/src/exec/redirect.c
@@ -6,7 +6,7 @@
 /*   By: mdekker/jde-baai <team@codam.nl>             +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2023/08/19 16:32:48 by mdekker/jde   #+#    #+#                 */
-/*   Updated: 2023/09/11 20:29:09 by mdekker/jde   ########   odam.nl         */
+/*   Updated: 2023/09/21 02:42:41 by mdekker/jde   ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -19,7 +19,7 @@ static void	out_redirect(t_group *group)
 	t_token	*red_out;
 
 	i = 0;
-	while (i < vec_len(&group->out_red))
+	while (i < (&group->out_red)->length)
 	{
 		red_out = vec_get(&group->out_red, i);
 		if (access(red_out->value, F_OK) == 0)
@@ -48,7 +48,7 @@ static void	in_redirect(t_group *group)
 	int		fd;
 
 	i = 0;
-	while (i < vec_len(&group->in_red))
+	while (i < (&group->in_red)->length)
 	{
 		red_in = vec_get(&group->in_red, i);
 		if (access(red_in->value, F_OK) == -1)

--- a/src/lexer/token.c
+++ b/src/lexer/token.c
@@ -5,69 +5,110 @@
 /*                                                     +:+                    */
 /*   By: mdekker/jde-baai <team@codam.nl>             +#+                     */
 /*                                                   +#+                      */
-/*   Created: 2023/07/21 13:06:18 by mdekker/jde   #+#    #+#                 */
-/*   Updated: 2023/09/15 17:10:23 by mdekker/jde   ########   odam.nl         */
+/*   Created: 2023/09/03 19:55:34 by mdekker/jde   #+#    #+#                 */
+/*   Updated: 2023/09/21 01:50:38 by mdekker/jde   ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include <minishell.h>
 
-static bool	find_operator(t_token *token)
+/**
+ * @note currently not including bonus,
+	counting & and | only as invidual operators
+ */
+static size_t	split_size(char *str)
 {
-	int	i;
+	size_t	split;
+	size_t	i;
 
+	split = 0;
 	i = 0;
-	while (token->value[i] && !checkchar(token->value[i], "<>|&"))
-		i++;
-	if (token->value[i] == '\0')
+	while (str[i])
+	{
+		if (checkchar(str[i], "<>|&"))
+		{
+			split++;
+			if (str[i + 1] && str[i] == str[i + 1])
+				i++;
+			i++;
+		}
+		if (!checkchar(str[i], "<>|&"))
+		{
+			split++;
+			while (str[i] && !checkchar(str[i], "<>|&"))
+				i++;
+		}
+	}
+	return (split);
+}
+
+static bool	split_operator(char *str, char **array, size_t *split, size_t *i)
+{
+	size_t	len;
+
+	len = 1;
+	if (str[(*i) + 1] && str[(*i)] == str[(*i) + 1])
+		len++;
+	array[(*split)] = malloc(sizeof(char *) * (len + 1));
+	if (!array[(*split)])
 		return (false);
+	array[(*split)][len] = '\0';
+	array[(*split)][0] = str[(*i)];
+	if (str[(*i) + 1] && str[(*i)] == str[(*i) + 1])
+		array[(*split)][1] = str[(*i) + 1];
+	(*i) += len;
+	(*split)++;
 	return (true);
 }
 
-static void	insert_array(t_shell *data, char **array, int i)
+static bool	split_non_operator(char *str, char **array, size_t *split,
+		size_t *i)
 {
-	int		j;
-	t_token	*token;
+	size_t	len;
 
-	j = 0;
-	while (array[j])
+	len = 0;
+	while (str[(*i + len)] && !checkchar(str[(*i) + len], "<>|&"))
+		len++;
+	array[(*split)] = malloc(sizeof(char *) * (len + 1));
+	if (!array[(*split)])
+		return (false);
+	array[(*split)][len] = '\0';
+	len = 0;
+	while (str[(*i) + len] && !checkchar(str[(*i) + len], "<>|&"))
 	{
-		token = create_token(array[j], UNKNOWN);
-		if (!token || !vec_insert(&data->token_vec, i + j, token))
-		{
-			ft_free(array);
-			set_err(MALLOC, "malloc", data);
-			break ;
-		}
-		j++;
+		array[(*split)][len] = str[(*i) + len];
+		len++;
 	}
+	(*i) += len;
+	(*split)++;
+	return (true);
 }
 
-bool	operator_split(t_shell *data)
+char	**split(t_token *token)
 {
 	size_t	i;
-	t_token	*token;
+	size_t	split;
 	char	**array;
 
+	split = split_size(token->value);
+	array = malloc(sizeof(char *) * (split + 1));
+	if (!array)
+		return (NULL);
+	array[split] = NULL;
+	split = 0;
 	i = 0;
-	while (i < (&data->token_vec)->length)
+	while (token->value[i])
 	{
-		token = (t_token *)vec_get(&data->token_vec, i);
-		if (token->type == STRING && find_operator(token))
+		if (checkchar(token->value[i], "<>|&"))
 		{
-			array = split(token);
-			if (!array || !vec_remove(&data->token_vec, i))
-			{
-				ft_free(array);
-				return (set_err(MALLOC, "op_split", data));
-			}
-			insert_array(data, array, i);
-			free(array);
+			if (!split_operator(token->value, array, &split, &i))
+				return (ft_free(array), NULL);
 		}
 		else
-			i++;
+		{
+			if (!split_non_operator(token->value, array, &split, &i))
+				return (ft_free(array), NULL);
+		}
 	}
-	if (array)
-		free(array);
-	return (parser(data), true);
+	return (array);
 }

--- a/src/main.c
+++ b/src/main.c
@@ -6,7 +6,7 @@
 /*   By: mdekker/jde-baai <team@codam.nl>             +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2023/07/12 14:11:01 by mdekker/jde   #+#    #+#                 */
-/*   Updated: 2023/09/21 02:39:25 by mdekker/jde   ########   odam.nl         */
+/*   Updated: 2023/09/21 03:11:26 by mdekker/jde   ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -79,10 +79,11 @@ int	main(int ac, char **av, char **env)
 		if (!lexer(av[1], data))
 			write_err(data);
 		parser(data);
+		// print_vector(&data->token_vec, print_token);
 		operator_split(data);
+		// print_vector(&data->token_vec, print_token);
 		// if (!check_tokens(data))
 		// 	return (write_err(data), free_shell(data, true), 1);
-		// print_vector(&data->token_vec, print_token);
 		// combine redirects+heredoc into 1 token + verify_token_vec combined
 		// verify_token_vec(data);
 		// expansion based on env vector

--- a/src/main.c
+++ b/src/main.c
@@ -6,7 +6,7 @@
 /*   By: mdekker/jde-baai <team@codam.nl>             +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2023/07/12 14:11:01 by mdekker/jde   #+#    #+#                 */
-/*   Updated: 2023/09/15 17:01:39 by mdekker/jde   ########   odam.nl         */
+/*   Updated: 2023/09/21 02:39:25 by mdekker/jde   ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -71,9 +71,6 @@ int	main(int ac, char **av, char **env)
 {
 	t_shell	*data;
 
-	// pid_t	pid;
-	// int		status;
-	// t_found	**found;
 	if (DEBUG)
 		debug();
 	data = init_shell(env, true);
@@ -81,22 +78,17 @@ int	main(int ac, char **av, char **env)
 	{
 		if (!lexer(av[1], data))
 			write_err(data);
-		// lexer retester
 		parser(data);
-		// parser retesting
 		operator_split(data);
-		// print sizeof t_found
-		// printf("%zu\n", sizeof(t_shell));
-		print_vector(&data->token_vec, print_token);
-		if (!check_tokens(data))
-			return (write_err(data), free_shell(data, true), 1);
-		print_vector(&data->token_vec, print_token);
+		// if (!check_tokens(data))
+		// 	return (write_err(data), free_shell(data, true), 1);
+		// print_vector(&data->token_vec, print_token);
 		// combine redirects+heredoc into 1 token + verify_token_vec combined
 		// verify_token_vec(data);
 		// expansion based on env vector
 		// group_token_vec(data);
 		// // check if all groups are properly cerated
-		// status = executor(data->exec);
+		// executor(data->exec);
 		free_shell(data, true);
 		return (0); // change this to return built_in_exit
 	}

--- a/src/parser/index.c
+++ b/src/parser/index.c
@@ -6,7 +6,7 @@
 /*   By: mdekker/jde-baai <team@codam.nl>             +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2023/07/20 11:12:20 by mdekker       #+#    #+#                 */
-/*   Updated: 2023/09/15 17:05:08 by mdekker/jde   ########   odam.nl         */
+/*   Updated: 2023/09/20 22:42:31 by mdekker/jde   ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -87,7 +87,11 @@ bool	parser(t_shell *data)
 
 	func_map = return_map();
 	if (func_map == NULL)
-		return (set_err(MALLOC, "parser", data), free(func_map));
+	{
+		free(func_map);
+		return (set_err(MALLOC, "parser", data));
+	}
 	parse_loop(&data->token_vec, func_map);
 	free(func_map);
+	return (true);
 }

--- a/src/parser/index.c
+++ b/src/parser/index.c
@@ -6,7 +6,7 @@
 /*   By: mdekker/jde-baai <team@codam.nl>             +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2023/07/20 11:12:20 by mdekker       #+#    #+#                 */
-/*   Updated: 2023/09/20 22:42:31 by mdekker/jde   ########   odam.nl         */
+/*   Updated: 2023/09/21 02:59:51 by mdekker/jde   ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -68,7 +68,7 @@ void	parse_loop(t_vector *vec, t_func_map *func_map)
 					break ;
 			}
 			token->type = func_map[j].type;
-			print_token(token, j);
+			// print_token(token, j);
 		}
 		i++;
 	}

--- a/src/utils/error.c
+++ b/src/utils/error.c
@@ -6,7 +6,7 @@
 /*   By: mdekker/jde-baai <team@codam.nl>             +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2023/07/19 21:42:24 by mdekker/jde   #+#    #+#                 */
-/*   Updated: 2023/09/15 17:04:26 by mdekker/jde   ########   odam.nl         */
+/*   Updated: 2023/09/21 02:47:48 by mdekker/jde   ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -69,7 +69,7 @@ void	write_err(t_shell *data)
 	if (data->exit_type == SYNTAX)
 	{
 		write(STDERR_FILENO, "minishell: syntax error near unexpected token `",
-				47);
+			47);
 		write(STDERR_FILENO, data->exit_msg, ft_strlen(data->exit_msg));
 		write(STDERR_FILENO, "'\n", 2);
 		g_signal.exit_status = 258;
@@ -79,6 +79,13 @@ void	write_err(t_shell *data)
 		write(STDERR_FILENO, "minishell: unfinished operator : `", 34);
 		write(STDERR_FILENO, data->exit_msg, ft_strlen(data->exit_msg));
 		write(STDERR_FILENO, "`\n", 2);
+		g_signal.exit_status = 2;
+	}
+	if (data->exit_type == OUT_OF_SCOPE)
+	{
+		write(STDERR_FILENO, "minishell: operator: `", 34);
+		write(STDERR_FILENO, data->exit_msg, ft_strlen(data->exit_msg));
+		write(STDERR_FILENO, "`: out of project scope\n", 25);
 		g_signal.exit_status = 2;
 	}
 	if (data->exit_type == SIGNAL_C)


### PR DESCRIPTION
Readline submodule werkte niet op linux. Maar op alle nieuwe linux staat readline standaard ingesteld. Heb de submodule verwijdert, op mijn mac werkt het iig ook met standaard readline library.

Ook nog een linux ding:
🧹  Cleaning up...              Warning: 'C' is not in the list of known options, but still passed to Electron/Chromium.
✅
🧹  Removing executable...      Warning: 'C' is not in the list of known options, but still passed to Electron/Chromium.
✅

-Ik heb operator split denk ik werkent gemaakt maar voel je vrij om nog te testen. De leaks functie die jij in main hebt gezet geeft een leak aan maar valgrind geen memory leaks. Ik kan leaks overigens ook niet callen in terminal dus betwijfel of die functie nog werkt.
- Bij het splitsen bedacht ik dat mensen ook enkele & kunnen callen, dit is een operator die moet zorgen voor een OUT_OF_SCOPE error aangezien we hier geen rekening mee hoeven te houden, kan je dit aan parser toevoegen? Dit kunnen we ook gebruiken indien we bonus niet doet(lijkt me wel een goed idee om niet te doen)

Verder als je het er mee eens bent dat operator split werkt kan je het met main mergen